### PR TITLE
Fix configuration error when connecting to Spotify for the first time

### DIFF
--- a/src/youspotube/api/spotify.py
+++ b/src/youspotube/api/spotify.py
@@ -19,7 +19,7 @@ class Spotify:
         # _init_connection should have been called in order to be able to use this property
         auth_manager = self.spotify.auth_manager
         token_info = auth_manager.cache_handler.get_cached_token()
-        if auth_manager.is_token_expired(token_info):
+        if token_info is not None and auth_manager.is_token_expired(token_info):
             self._init_connection()
         return self.spotify
 


### PR DESCRIPTION
When there was no .cache file, it had to ask Spotify for the tokens. However, since the token_info was None, it tried accessing something that never existed in the first place and failed with "Configuration error: Test connection to Spotify API failed: 'NoneType' object is not subscriptable"