### PR TITLE
Fix YouTube API connection failure

### DIFF
--- a/src/youspotube/api/youtube.py
+++ b/src/youspotube/api/youtube.py
@@ -11,7 +11,7 @@ class YouTube:
             raise ConfigurationError("Test connection to YouTube API failed: %s" % str(e))
 
     def _init_connection(self, api_key):
-        self.connection = build('youtube', 'v3', developerKey=api_key)
+        self.connection = build('youtube', 'v3', developerKey=api_key, static_discovery=False)
 
     def _test_connection(self):
         request = self.connection.channels().list(


### PR DESCRIPTION
Essentially, as described in googleapis/google-api-python-client#1109 and googleapis/google-api-python-client#876 - since version 2.0.0 google-api-python-client has included static documents for all Google Discovery APIs. To use them, you'd need to tell PyInstaller to include those static .json files in your build or use static_discovery=False which causes the library to dynamically download the API's discovery file from Google on build(). Otherwise, pyinstaller builds will fail.