### PR TITLE
Official support for (messy) bidirectional synchronization

### DIFF
--- a/src/youspotube/constants.py
+++ b/src/youspotube/constants.py
@@ -29,7 +29,7 @@ SPOTIFY_CALLBACK_URL = 'http://localhost:4466'
 SPOTIFY_SCOPE = 'user-read-private playlist-modify-public playlist-read-private playlist-modify-private'
 SPOTIFY_TRACK_ID_DATA_KEY = 'track_id'
 SPOTIFY_TRACK_TITLE_ARTISTS_DATA_KEY = 'track_title_artists'
-SPOTIFY_SEARCH_LIMIT = 5
+SPOTIFY_SEARCH_LIMIT = 1
 
 YOUTUBE_API_URL = 'https://www.googleapis.com/youtube/v3/'
 YOUTUBE_TOKEN_STORAGE_FILE = '.youtube_cache'

--- a/src/youspotube/execution/executor.py
+++ b/src/youspotube/execution/executor.py
@@ -18,8 +18,8 @@ class Execution:
 
     def get_sync_arrow(self):
         origin = self.params[constants.ORIGIN_PARAMETER]
-        arrow_sides = ["YouTube", "Spotify"]
-        if origin == constants.ORIGIN_SPOTIFY:
+        arrow_sides = ["Spotify", "YouTube"]
+        if origin == constants.ORIGIN_YOUTUBE:
             arrow_sides.reverse()
 
         arrow = '-' * 10 + '> '


### PR DESCRIPTION
Essentially, it cannot be any better. The Spotify search is extremely broken, as indicated by several complaints over the Internet: https://community.spotify.com/t5/Desktop-Windows/Search-shows-a-massive-amount-of-irrelevant-results-and-there-is/td-p/4999290

One of the issues is that *some* songs will not be found and that remains unsolved (and that's directly due to the broken Spotify search algorithm) - Spotify returns an absolutely irrelevant song sometimes as "best" match and after that is looked back on YouTube, of course, youspotube figures out that whatever Spotify returned as a 'best match' is far from best.

Another issue is that sometimes a song or two might get duplicated in Spotify (but it's not exactly the same track - it's just exactly the SAME song, but uploaded by a different artist). Even with a limit of 5 search results that are then checked within the playlist for their presence, some songs still get duplicated - and that's again due to Spotify's search algorithm and their lack of control over the same content being uploaded by totally unrelated artists (i.e. TikTok Top Songs). Maybe it's high time for them to implement content ID as well. Extending the search results limit causes problems on its own, more on that in the next paragraph...

A third issue was that Spotify doesn't limit itself to displaying only whatever is relevant for you - why should they? They dump a 1000 results, you pick your threshold and the relevant track. Therefore, when the search limit is rather big (and sometimes limit of 2 songs is too big!) Spotify returns songs by the same artist as # 2, # 3 etc and when youspotube checks if those search results are already in the playlist in order to mitigate the issue in the previous paragraph, it sometimes finds other songs by the same artist in there as well and won't add the # 1 search result that is actually missing in the playlist.

This applies both for bidirectional syncs part YouTube -> Spotify and the regular YouTube -> Spotify sync.

Thus, the search results limit is back to 1. If someone knows a better way to handle it, feel free ot open a PR. It's better to have duplicates than to miss your beloved songs.

Alas, I have to admit that YouTube is the superior platform for music. And I thought that Spotify was the one when I started this project.